### PR TITLE
Fix end cut map key for ios

### DIFF
--- a/ios/Classes/Method/BrotherUtils.m
+++ b/ios/Classes/Method/BrotherUtils.m
@@ -729,7 +729,7 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     
     printerSettings.labelSize = [BrotherUtils qlLabelSizeWithName:labelName];
     printerSettings.autoCut = [[map objectForKey:@"isAutoCut"] isEqual:@(YES)];
-    printerSettings.cutAtEnd = [[map objectForKey:@"isEndCut"] isEqual:@(YES)];
+    printerSettings.cutAtEnd = [[map objectForKey:@"isCutAtEnd"] isEqual:@(YES)];
     printerSettings.resolution = [BrotherUtils printResolutionFromMapWithValue:dartPrintQuality];
     
     // TODO Extract info from map.
@@ -2283,7 +2283,7 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     NSDictionary<NSString*, NSObject *> * dartLabelInfoStatus = @{
         @"labelNameIndex": [BrotherUtils labelIdTypeToNumberWithValue: [status labelID ]],
         @"isAutoCut": @FALSE, // TODO
-        @"isEndCut": @FALSE, // TODO
+        @"isCutAtEnd": @FALSE, // TODO
         @"isHalfCut": @FALSE, // TODO
         @"isSpecialTape": @FALSE, // TODO
         @"isCutMark": @FALSE, // TODO


### PR DESCRIPTION
Seems the iOS key used in the map differs from the one used for Android and thus the end cut functionality doesn't work under iOS. Here is a reference of the key usage for android:
https://github.com/CodeMinion/another_brother/blob/736f231e3f02a6e9aba51f3cb1131e48e4942e29/android/src/main/kotlin/com/rouninlabs/another_brother/method/BrotherUtils.kt#L52

This PR adjusts the map key that is used in iOS so that it works correctly. 