### PR TITLE
Add support for auto cut every page count

### DIFF
--- a/android/src/main/kotlin/com/rouninlabs/another_brother/method/BrotherUtils.kt
+++ b/android/src/main/kotlin/com/rouninlabs/another_brother/method/BrotherUtils.kt
@@ -49,6 +49,7 @@ fun printerInfofromMap(context:Context, flutterAssets: FlutterPlugin.FlutterAsse
         mirrorPrint = map["mirrorPrint"] as Boolean
         paperPosition = alignFromMap(map["paperPosition"] as Map<String, Any>)
         isAutoCut = map["isAutoCut"] as Boolean
+        numberOfAutoCutPages = map["autoCutForEachPageCount"] as Int
         isCutAtEnd = map["isCutAtEnd"] as Boolean
         mode9 = map["mode9"] as Boolean
         skipStatusCheck = map["skipStatusCheck"] as Boolean

--- a/ios/Classes/Method/BrotherUtils.m
+++ b/ios/Classes/Method/BrotherUtils.m
@@ -729,16 +729,9 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     
     printerSettings.labelSize = [BrotherUtils qlLabelSizeWithName:labelName];
     printerSettings.autoCut = [[map objectForKey:@"isAutoCut"] isEqual:@(YES)];
+    printerSettings.autoCutForEachPageCount = (UInt8)[(NSNumber *)[map objectForKey:@"autoCutForEachPageCount"] integerValue];
     printerSettings.cutAtEnd = [[map objectForKey:@"isEndCut"] isEqual:@(YES)];
     printerSettings.resolution = [BrotherUtils printResolutionFromMapWithValue:dartPrintQuality];
-    
-    // TODO Extract info from map.
-    //[x]labelSize
-    //autoCutForEachPageCount
-    //[x]autoCut
-    //[x]cutAtEnd
-    //[x]resolution
-    
     
     NSDictionary<NSString*, NSObject*> * dartPrintMode = (NSDictionary<NSString*, NSObject*> *)[map objectForKey:@"printMode"];
     
@@ -1315,6 +1308,7 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     
     bool cutmarkPrint = [[map objectForKey:@"isCutMark"] isEqual:@(YES)];
     bool autoCut = [[map objectForKey:@"isAutoCut"] isEqual:@(YES)];
+    UInt8 autoCutForEachPageCount = [(NSNumber *)[map objectForKey:@"autoCutForEachPageCount"] integerValue];
     bool halfCut = [[map objectForKey:@"isHalfCut"] isEqual:@(YES)];
     bool specialTapePrint = [[map objectForKey:@"isSpecialTape"] isEqual:@(YES)];
     
@@ -1329,6 +1323,7 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     printerSettings.labelSize = [BrotherUtils ptLabelSizeWithName:labelName];
     printerSettings.cutmarkPrint = cutmarkPrint;
     printerSettings.autoCut = autoCut;
+    printerSettings.autoCutForEachPageCount = autoCutForEachPageCount;
     printerSettings.halfCut = halfCut;
     printerSettings.specialTapePrint = specialTapePrint;
     printerSettings.resolution = [BrotherUtils printResolutionFromMapWithValue:dartResolution];
@@ -1338,7 +1333,6 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     
     // chainPrint @"???"
     // highResolutionPrint @"???"
-    // autoCutForEachPageCount @"???"
     //
     
     return printerSettings;
@@ -2283,6 +2277,7 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     NSDictionary<NSString*, NSObject *> * dartLabelInfoStatus = @{
         @"labelNameIndex": [BrotherUtils labelIdTypeToNumberWithValue: [status labelID ]],
         @"isAutoCut": @FALSE, // TODO
+        @"autoCutForEachPageCount": @1, // TODO
         @"isEndCut": @FALSE, // TODO
         @"isHalfCut": @FALSE, // TODO
         @"isSpecialTape": @FALSE, // TODO

--- a/lib/printer_info.dart
+++ b/lib/printer_info.dart
@@ -1470,6 +1470,7 @@ class PrinterInfo {
   bool rotate180;
   bool peelMode;
   bool isAutoCut;
+  int autoCutForEachPageCount;
   bool isCutAtEnd;
   bool isSpecialTape;
   bool isHalfCut;
@@ -1515,6 +1516,7 @@ class PrinterInfo {
       this.mirrorPrint = false,
       this.paperPosition = Align.CENTER,
       this.isAutoCut = true,
+      this.autoCutForEachPageCount = 1,
       this.isCutAtEnd = true,
       this.mode9 = true,
       this.skipStatusCheck = false,
@@ -1601,6 +1603,7 @@ class PrinterInfo {
         mirrorPrint: map["mirrorPrint"],
         paperPosition: Align.fromMap(map["paperPosition"]),
         isAutoCut: map["isAutoCut"],
+        autoCutForEachPageCount: map["autoCutForEachPageCount"],
         isCutAtEnd: map["isCutAtEnd"],
         mode9: map["mode9"],
         skipStatusCheck: map["skipStatusCheck"],
@@ -1664,6 +1667,7 @@ class PrinterInfo {
       "mirrorPrint": mirrorPrint,
       "paperPosition": paperPosition.toMap(),
       "isAutoCut": isAutoCut,
+      "autoCutForEachPageCount": autoCutForEachPageCount,
       "isCutAtEnd": isCutAtEnd,
       "mode9": mode9,
       "skipStatusCheck": skipStatusCheck,


### PR DESCRIPTION
I have a project where I need to cut every 2 labels, so this PR adds support for the `numberOfAutoCutPages` from the brother SDK. Tested under iOS 18.3.1 using QL-820NWBc printer connected over BLE. 

I'm not sure but seems for Android the property is named differently (although I could not find it on the brother SDK pages). Would be good if someone could test/verify the android changes also work as expected. 